### PR TITLE
Refactor FunctionTool model to use default factory for parameters and…

### DIFF
--- a/app/yandex/models.py
+++ b/app/yandex/models.py
@@ -45,7 +45,15 @@ class Message(BaseModel):
 class FunctionTool(BaseModel):
     name: str
     description: str = Field(default="")
-    parameters: Dict[str, Any] = Field(default={})
+    parameters: Dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode='before')
+    def set_empty_defaults(cls, values):
+        if values.description is None:
+            values.description = ""
+        if values.parameters is None:
+            values.parameters = {}
+        return values
 
 class Tool(BaseModel):
     function: FunctionTool

--- a/app/yandex/models.py
+++ b/app/yandex/models.py
@@ -47,7 +47,7 @@ class FunctionTool(BaseModel):
     description: str = Field(default="")
     parameters: Dict[str, Any] = Field(default_factory=dict)
 
-    @model_validator(mode='before')
+    @model_validator(mode='after')
     def set_empty_defaults(cls, values):
         if values.description is None:
             values.description = ""


### PR DESCRIPTION
… add validation for empty fields

- Updated the FunctionTool model to utilize `default_factory` for the parameters field, ensuring it defaults to an empty dictionary.
- Introduced a model validator to set default values for description and parameters if they are not provided, enhancing data integrity.

These changes improve the robustness of the FunctionTool model by ensuring that it handles missing values appropriately.